### PR TITLE
Removing inline-block from card container

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -77,7 +77,7 @@
       "login": "jrock2004",
       "name": "John Costanzo",
       "avatar_url": "https://avatars.githubusercontent.com/u/655716?v=4",
-      "profile": "http://jcwebconcepts.net/",
+      "profile": "https://github.com/jrock2004",
       "contributions": [
         "bug",
         "code"

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -72,6 +72,16 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "jrock2004",
+      "name": "John Costanzo",
+      "avatar_url": "https://avatars.githubusercontent.com/u/655716?v=4",
+      "profile": "http://jcwebconcepts.net/",
+      "contributions": [
+        "bug",
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/src/components/Board/components/Column/components/Card/index.js
+++ b/src/components/Board/components/Column/components/Card/index.js
@@ -11,7 +11,7 @@ function Card({ children, index, renderCard, disableCardDrag }) {
             {...provided.dragHandleProps}
             data-testid={`card-${children.id}`}
           >
-            <div style={{ display: 'inline-block', whiteSpace: 'normal' }}>{renderCard(isDragging)}</div>
+            <div style={{ whiteSpace: 'normal' }}>{renderCard(isDragging)}</div>
           </div>
         )
       }}


### PR DESCRIPTION
### Description

Please include a summary of the change and the issue (if is related to a one)

This PR is to remove the inline-block inline style that is not necessary and is causing issues, see #442 . When I removed this style I tested on a Mac in browsers safari, Firefox, and chrome and it did not appear to affect the cards at all.

### Type of change

- [x] 🐛 Bug fix
- [ ] 💻 New feature
- [ ] 📖 Documentation
- [ ] 💅 Layout
- [ ] 🧹 Chore

### Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I updated the docs related to the changes

<!-- PLEASE, OPEN THIS PR AS DRAFT IF IT'S NOT THROUGH YET. -->
